### PR TITLE
Sourceにisbn, issn, start_page, end_page, article_number, volumeを追加

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -201,7 +201,12 @@ related_item:
 source:
   title: str()
   description: str(required=False)
-  identifier: str(required=False)
+  isbn: str(required=False)
+  issn: str(required=False)
+  start_page: int(required=False)
+  end_page: int(required=False)
+  article_number: str(required=False)
+  volume: str(required=False)
 
 ---
 # 会議


### PR DESCRIPTION
`Source`には、リポジトリに登録された論文の掲載誌の情報を記述することを企図しています。ここに`identifier`のかわりに、`isbn`と`issn`を追加するように変更しています。あわせて、巻号やページ数の記述も追加しています。

本スキーマで使用するIDには、`identifier`のような汎用的な項目と、`Creator`の`orcid`や`e_rad`のような明示的に指定された項目の両方があります。このPRで、`Source`も後者のように扱うようになります。