### PR TITLE
Enumerate data_origin_type to match the data model

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -354,7 +354,7 @@ right:
 ---
 # データの出所
 data_origin:
-  data_origin_type: str()
+  data_origin_type: enum('experiment', 'informatics_and_data_science', 'simulation', 'theory', 'other')
 
 ---
 # 件名


### PR DESCRIPTION
data_origin_type について読み込みシステム側は5つの語彙のどれかでないとエラーになるようなので、スキーマも enum 列挙にすべきかと思います。