### PR TITLE
required=False for data_origin_type

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -354,7 +354,7 @@ right:
 ---
 # データの出所
 data_origin:
-  data_origin_type: enum('experiment', 'informatics_and_data_science', 'simulation', 'theory', 'other')
+  data_origin_type: enum('experiment', 'informatics_and_data_science', 'simulation', 'theory', 'other', required=False)
 
 ---
 # 件名


### PR DESCRIPTION
#10 において str を enum にしたことによってこの値を空欄にできなくなってしまい、

```yaml
data_origin:
  data_origin_type:
```

と値を書かずに空欄にしておくことが許されなくなり、バリデーションを通すためにはキーごと削除する必要が生じていたので、 required=False 指定によりこれを修正します。