### PR TITLE
thumbnailにfilenameを追加

### DIFF
--- a/metadata-sample.yaml
+++ b/metadata-sample.yaml
@@ -216,3 +216,11 @@ custom_properties: # 独自追加項目
 - name: 独自項目2
   value: ABCDE
   identifier: https://example.com
+
+filesets:
+- filename: image1.png
+- filename: image2.jpg
+- filename: image3.tif
+
+thumbnail:
+  filename: image1.png

--- a/schema.yaml
+++ b/schema.yaml
@@ -108,7 +108,7 @@ mdr_url: str(required=False)
 filesets: list(include('fileset'), required=False)
 
 # サムネイル。filesets内のfilenameを指定
-thumbnail: str(required=False)
+thumbnail: include('thumbnail_entry', required=False)
 
 # 試料
 specimens: list(include('specimen'), required=False)
@@ -383,3 +383,7 @@ collection:
 fileset:
   filename: str()
   content_type: str(required=False)
+
+# サムネイル。filesets内のfilenameを指定
+thumbnail_entry:
+  filename: str()


### PR DESCRIPTION
サムネイルのファイル名について、スキーマの定義では以下の構造になっていたのですが、

```yaml
filesets:
- filename: image1.png
- filename: image2.jpg
- filename: image3.tif

thumbnail: image1.png
```

正しくは以下のような構造を想定していました。

```yaml
filesets:
- filename: image1.png
- filename: image2.jpg
- filename: image3.tif

thumbnail:
  filename: image1.png
```
